### PR TITLE
Multiple enhancements and bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ target/
 .settings/
 .project
 .classpath
+.idea
+*.iml
+work/

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.620</version>
+    <version>1.609.2</version>
   </parent>
 
   <artifactId>harvest</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,59 +1,60 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <parent>
-    <groupId>org.jenkins-ci.plugins</groupId>
-    <artifactId>plugin</artifactId>
-    <version>1.609.2</version>
-  </parent>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>plugin</artifactId>
+        <version>1.609.2</version>
+    </parent>
 
-  <artifactId>harvest</artifactId>
-  <packaging>hpi</packaging>
-  <name>Jenkins Harvest SCM</name>
-  <description>Integrates Jenkins to CA Harvest SCM</description>
-  <version>0.5.1-SNAPSHOT</version>
-  <url>http://wiki.jenkins-ci.org/display/JENKINS/Harvest+Plugin</url>
+    <artifactId>harvest</artifactId>
+    <packaging>hpi</packaging>
+    <name>Jenkins Harvest SCM</name>
+    <description>Integrates Jenkins to CA Harvest SCM</description>
+    <version>0.5.1-SNAPSHOT</version>
+    <url>http://wiki.jenkins-ci.org/display/JENKINS/Harvest+Plugin</url>
 
-  <distributionManagement>
-   <repository>
-    <id>maven.jenkins-ci.org</id>
-    <url>http://maven.jenkins-ci.org:8081/content/repositories/releases/</url>
-   </repository>
-  </distributionManagement>
+    <distributionManagement>
+        <repository>
+            <id>maven.jenkins-ci.org</id>
+            <url>http://maven.jenkins-ci.org:8081/content/repositories/releases/</url>
+        </repository>
+    </distributionManagement>
 
-  <developers>
-    <developer>
-      <id>gliptak</id>
-      <name>G‡bor Lipt‡k</name>
-    </developer>
-  </developers>
+    <developers>
+        <developer>
+            <id>gliptak</id>
+            <name>G‡bor Lipt‡k</name>
+        </developer>
+    </developers>
 
-  <build>
-    <plugins>
-      <plugin>
-        <artifactId>maven-release-plugin</artifactId>
-        <configuration>
-          <goals>deploy</goals>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-release-plugin</artifactId>
+                <configuration>
+                    <goals>deploy</goals>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
-  <scm>
-    <connection>scm:git:git://github.com/jenkinsci/harvest-plugin.git</connection>
-    <developerConnection>scm:git:git@github.com:jenkinsci/harvest-plugin.git</developerConnection>
-    <url>http://github.com/jenkinsci/harvest-plugin</url>
-  </scm>
+    <scm>
+        <connection>scm:git:git://github.com/jenkinsci/harvest-plugin.git</connection>
+        <developerConnection>scm:git:git@github.com:jenkinsci/harvest-plugin.git</developerConnection>
+        <url>http://github.com/jenkinsci/harvest-plugin</url>
+    </scm>
 
-  <repositories>
-    <repository>
-       <id>repo.jenkins-ci.org</id>
-       <url>http://repo.jenkins-ci.org/public/</url>
-    </repository>
-  </repositories>
+    <repositories>
+        <repository>
+            <id>repo.jenkins-ci.org</id>
+            <url>http://repo.jenkins-ci.org/public/</url>
+        </repository>
+    </repositories>
 
-  <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-  </properties>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
 
 
     <pluginRepositories>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.400</version>
+    <version>1.620</version>
   </parent>
 
   <artifactId>harvest</artifactId>
@@ -23,7 +23,7 @@
   <developers>
     <developer>
       <id>gliptak</id>
-      <name>G‡bor Lipt‡k</name>
+      <name>Gâ€¡bor Liptâ€¡k</name>
     </developer>
   </developers>
 

--- a/src/main/java/hudson/plugins/harvest/HarvestChangeLogEntry.java
+++ b/src/main/java/hudson/plugins/harvest/HarvestChangeLogEntry.java
@@ -1,68 +1,66 @@
 package hudson.plugins.harvest;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-
 import hudson.model.User;
 import hudson.scm.ChangeLogSet;
 import hudson.scm.ChangeLogSet.Entry;
-
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.commons.lang.builder.ReflectionToStringBuilder;
 import org.kohsuke.stapler.export.Exported;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
 /**
  * @author G&aacute;bor Lipt&aacute;k
- *
  */
 public class HarvestChangeLogEntry extends Entry {
 
-	/**
-	 * @return the fullName
-	 */
-	public String getFullName() {
-		return fullName;
-	}
-
-	/**
-	 * @param fullName the fullName to set
-	 */
-	public void setFullName(String fullName) {
-		this.fullName = fullName;
-	}
-
-	protected String user=null;
-    protected String msg="";
+    protected String user = null;
+    protected String msg = "";
     protected String fullName = "";
     protected String version;
 
-	@Override
-	@Exported
-    public User getAuthor() {
-        return User.getUnknown();        	
+    /**
+     * @return the fullName
+     */
+    public String getFullName() {
+        return fullName;
     }
 
-	@Override
-	@Exported
+    /**
+     * @param fullName the fullName to set
+     */
+    public void setFullName(String fullName) {
+        this.fullName = fullName;
+    }
+
+    @Override
+    @Exported
+    public User getAuthor() {
+        return User.getUnknown();
+    }
+
+    @Override
+    @Exported
     public Collection<String> getAffectedPaths() {
-		List<String> l=new ArrayList<String>();
-		l.add(fullName);
+        List<String> l = new ArrayList<String>();
+        l.add(fullName);
         return l;
     }
-    
+
     /**
      * Overrides the setParent() method so the ClearCaseChangeLogSet can access it.
      */
-	@Override
-	@Exported
+    @Override
+    @Exported
     public void setParent(ChangeLogSet parent) {
         super.setParent(parent);
     }
 
-	@Override
-	@Exported
+    @Override
+    @Exported
     public String getMsg() {
         return msg;
     }
@@ -72,57 +70,57 @@ public class HarvestChangeLogEntry extends Entry {
     }
 
     /**
-	 * @return the version
-	 */
-	public String getVersion() {
-		return version;
-	}
-
-	/**
-	 * @param version the version to set
-	 */
-	public void setVersion(String version) {
-		this.version = version;
-	}
+     * @return the version
+     */
+    public String getVersion() {
+        return version;
+    }
 
     /**
-	 * @return the user
-	 */
-	public String getUser() {
-		return user;
-	}
+     * @param version the version to set
+     */
+    public void setVersion(String version) {
+        this.version = version;
+    }
 
-	/**
-	 * @param user the user to set
-	 */
-	public void setUser(String user) {
-		this.user = user;
-	}
+    /**
+     * @return the user
+     */
+    public String getUser() {
+        return user;
+    }
+
+    /**
+     * @param user the user to set
+     */
+    public void setUser(String user) {
+        this.user = user;
+    }
 
     /* (non-Javadoc)
-	 * @see java.lang.Object#equals(java.lang.Object)
+     * @see java.lang.Object#equals(java.lang.Object)
 	 */
-	@Override
-	public boolean equals(Object obj) {
-		// TODO Auto-generated method stub
-		return EqualsBuilder.reflectionEquals(this, obj);
-	}
+    @Override
+    public boolean equals(Object obj) {
+        // TODO Auto-generated method stub
+        return EqualsBuilder.reflectionEquals(this, obj);
+    }
 
-	/* (non-Javadoc)
-	 * @see java.lang.Object#hashCode()
-	 */
-	@Override
-	public int hashCode() {
-		// TODO Auto-generated method stub
-		return HashCodeBuilder.reflectionHashCode(this);
-	}
+    /* (non-Javadoc)
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        // TODO Auto-generated method stub
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
 
-	/* (non-Javadoc)
-	 * @see java.lang.Object#toString()
-	 */
-	@Override
-	public String toString() {
-		// TODO Auto-generated method stub
-		return ReflectionToStringBuilder.toString(this);
-	}
+    /* (non-Javadoc)
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        // TODO Auto-generated method stub
+        return ReflectionToStringBuilder.toString(this);
+    }
 }

--- a/src/main/java/hudson/plugins/harvest/HarvestChangeLogParser.java
+++ b/src/main/java/hudson/plugins/harvest/HarvestChangeLogParser.java
@@ -1,24 +1,22 @@
 package hudson.plugins.harvest;
 
-import java.io.File;
-import java.io.IOException;
-
-import org.xml.sax.SAXException;
-
 import hudson.model.AbstractBuild;
 import hudson.scm.ChangeLogParser;
 import hudson.scm.ChangeLogSet;
+import org.xml.sax.SAXException;
+
+import java.io.File;
+import java.io.IOException;
 
 /**
  * @author G&aacute;bor Lipt&aacute;k
- *
  */
 public class HarvestChangeLogParser extends ChangeLogParser {
 
-	@Override
-	public ChangeLogSet<HarvestChangeLogEntry> parse(AbstractBuild build, File changelogFile)
-			throws IOException, SAXException {
+    @Override
+    public ChangeLogSet<HarvestChangeLogEntry> parse(AbstractBuild build, File changelogFile)
+            throws IOException, SAXException {
         return HarvestChangeLogSet.parse(build, changelogFile);
-	}
+    }
 
 }

--- a/src/main/java/hudson/plugins/harvest/HarvestChangeLogSet.java
+++ b/src/main/java/hudson/plugins/harvest/HarvestChangeLogSet.java
@@ -1,70 +1,45 @@
 package hudson.plugins.harvest;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.PrintStream;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-
+import hudson.model.AbstractBuild;
+import hudson.scm.ChangeLogSet;
 import org.apache.commons.digester.Digester;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.commons.lang.builder.ReflectionToStringBuilder;
 import org.xml.sax.SAXException;
 
-import hudson.model.AbstractBuild;
-import hudson.scm.ChangeLogSet;
+import java.io.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
 
 /**
  * @author G&aacute;bor Lipt&aacute;k
- *
  */
 public class HarvestChangeLogSet extends ChangeLogSet<HarvestChangeLogEntry> {
 
-	private List<HarvestChangeLogEntry> history = null;
+    private List<HarvestChangeLogEntry> history = null;
 
-	public HarvestChangeLogSet(AbstractBuild<?, ?> build, List<HarvestChangeLogEntry> logs) {
+    public HarvestChangeLogSet(AbstractBuild<?, ?> build, List<HarvestChangeLogEntry> logs) {
         super(build);
         for (HarvestChangeLogEntry entry : logs) {
             entry.setParent(this);
         }
         this.history = Collections.unmodifiableList(logs);
-	}
-
-	@Override
-	public boolean isEmptySet() {
-        return history.size() == 0;
-	}
-
-	public Iterator<HarvestChangeLogEntry> iterator() {
-		return history.iterator();
-	}
-
-//    @Override
-//    public String getKind() {
-//        return "harvest";
-//    }
-
-    public List<HarvestChangeLogEntry> getLogs() {
-        return history;
     }
 
-	public static ChangeLogSet<HarvestChangeLogEntry> parse(AbstractBuild<?,?> build, File changeLogFile) throws IOException, SAXException {
+    public static ChangeLogSet<HarvestChangeLogEntry> parse(AbstractBuild<?, ?> build, File changeLogFile) throws IOException, SAXException {
         InputStream fileInputStream = new FileInputStream(changeLogFile);
         HarvestChangeLogSet logSet = parse(build, fileInputStream);
         fileInputStream.close();
         return logSet;
-	}
+    }
 
-	protected static HarvestChangeLogSet parse(AbstractBuild<?,?> build, InputStream inputStream) throws IOException, SAXException {
-		List<HarvestChangeLogEntry> history=new ArrayList<HarvestChangeLogEntry>();
+    protected static HarvestChangeLogSet parse(AbstractBuild<?, ?> build, InputStream inputStream) throws IOException, SAXException {
+        List<HarvestChangeLogEntry> history = new ArrayList<HarvestChangeLogEntry>();
 
-		// Parse the change log file.
+        // Parse the change log file.
         Digester digester = new Digester();
         digester.setClassLoader(HarvestChangeLogSet.class.getClassLoader());
         digester.push(history);
@@ -79,13 +54,18 @@ public class HarvestChangeLogSet extends ChangeLogSet<HarvestChangeLogEntry> {
         digester.parse(inputStream);
 
         return new HarvestChangeLogSet(build, history);
-	}
+    }
+
+//    @Override
+//    public String getKind() {
+//        return "harvest";
+//    }
 
     /**
      * Stores the history objects to the output stream as xml
-     * 
+     *
      * @param outputStream the stream to write to
-     * @param history the history objects to store
+     * @param history      the history objects to store
      * @throws IOException
      */
     public static void saveToChangeLog(OutputStream outputStream, ChangeLogSet<HarvestChangeLogEntry> history)
@@ -94,50 +74,63 @@ public class HarvestChangeLogSet extends ChangeLogSet<HarvestChangeLogEntry> {
 
         stream.println("<?xml version='1.0' encoding='UTF-8'?>");
         stream.println("<history>");
-        for (HarvestChangeLogEntry entry: history) {
-        	stream.println("<entry>");
-        	stream.print("<user>");
-        	stream.print(entry.getAuthor());
-        	stream.println("</user>");
-        	stream.print("<msg>");
-        	stream.print(entry.getMsgEscaped());
-        	stream.println("</msg>");
-        	stream.print("<fullName>");
-        	stream.print(entry.getFullName());
-        	stream.println("</fullName>");        		
-        	stream.print("<version>");
-        	stream.print(entry.getVersion());
-        	stream.println("</version>");        		
-        	stream.println("</entry>");
+        for (HarvestChangeLogEntry entry : history) {
+            stream.println("<entry>");
+            stream.print("<user>");
+            stream.print(entry.getAuthor());
+            stream.println("</user>");
+            stream.print("<msg>");
+            stream.print(entry.getMsgEscaped());
+            stream.println("</msg>");
+            stream.print("<fullName>");
+            stream.print(entry.getFullName());
+            stream.println("</fullName>");
+            stream.print("<version>");
+            stream.print(entry.getVersion());
+            stream.println("</version>");
+            stream.println("</entry>");
         }
         stream.println("</history>");
         stream.close();
     }
-    
+
+    @Override
+    public boolean isEmptySet() {
+        return history.size() == 0;
+    }
+
+    public Iterator<HarvestChangeLogEntry> iterator() {
+        return history.iterator();
+    }
+
+    public List<HarvestChangeLogEntry> getLogs() {
+        return history;
+    }
+
     /* (non-Javadoc)
-	 * @see java.lang.Object#equals(java.lang.Object)
+     * @see java.lang.Object#equals(java.lang.Object)
 	 */
-	@Override
-	public boolean equals(Object obj) {
-		// TODO Auto-generated method stub
-		return EqualsBuilder.reflectionEquals(this, obj);
-	}
+    @Override
+    public boolean equals(Object obj) {
+        // TODO Auto-generated method stub
+        return EqualsBuilder.reflectionEquals(this, obj);
+    }
 
-	/* (non-Javadoc)
-	 * @see java.lang.Object#hashCode()
-	 */
-	@Override
-	public int hashCode() {
-		// TODO Auto-generated method stub
-		return HashCodeBuilder.reflectionHashCode(this);
-	}
+    /* (non-Javadoc)
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        // TODO Auto-generated method stub
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
 
-	/* (non-Javadoc)
-	 * @see java.lang.Object#toString()
-	 */
-	@Override
-	public String toString() {
-		// TODO Auto-generated method stub
-		return ReflectionToStringBuilder.toString(this);
-	}
+    /* (non-Javadoc)
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        // TODO Auto-generated method stub
+        return ReflectionToStringBuilder.toString(this);
+    }
 }

--- a/src/main/java/hudson/plugins/harvest/HarvestSCM.java
+++ b/src/main/java/hudson/plugins/harvest/HarvestSCM.java
@@ -3,28 +3,17 @@
  */
 package hudson.plugins.harvest;
 
-import java.io.BufferedReader;
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.FileReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.nio.file.FileAlreadyExistsException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import javax.servlet.ServletException;
-
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.Util;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.BuildListener;
+import hudson.model.TaskListener;
+import hudson.scm.*;
+import hudson.util.ArgumentListBuilder;
+import hudson.util.FormValidation;
 import net.sf.json.JSONObject;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
@@ -35,31 +24,24 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
-import hudson.Extension;
-import hudson.FilePath;
-import hudson.Launcher;
-import hudson.Util;
-import hudson.model.AbstractBuild;
-import hudson.model.AbstractProject;
-import hudson.model.BuildListener;
-import hudson.model.TaskListener;
-import hudson.scm.ChangeLogParser;
-import hudson.scm.ChangeLogSet;
-import hudson.scm.PollingResult;
-import hudson.scm.SCMRevisionState;
-import hudson.scm.SCM;
-import hudson.scm.SCMDescriptor;
-import hudson.util.ArgumentListBuilder;
-import hudson.util.FormValidation;
+import javax.servlet.ServletException;
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * @author G&aacute;bor Lipt&aacute;k
- *
  */
 public class HarvestSCM extends SCM {
 
-	private String broker = null;
-	private String passwordFile = null;
+    private final Log logger = LogFactory.getLog(getClass());
+    private String broker = null;
+    private String passwordFile = null;
     private String userId = null;
     private String password = null;
     private String projectName = null;
@@ -68,157 +50,156 @@ public class HarvestSCM extends SCM {
     private String clientPath = null;
     private String processName = null;
     private String recursiveSearch = null;
-	private boolean useSynchronize=true;
-	private String extraOptions=null;
+    private boolean useSynchronize = true;
+    private String extraOptions = null;
 
-	/**
-	 * Constructor
-	 * @param broker
-	 * @param userId
-	 * @param password
-	 * @param projectName
-	 * @param state
-	 * @param viewPath
-	 * @param clientPath
-	 * @param processName
-	 * @param recursiveSearch
-	 */
+    /**
+     * Constructor
+     *
+     * @param broker
+     * @param userId
+     * @param password
+     * @param projectName
+     * @param state
+     * @param viewPath
+     * @param clientPath
+     * @param processName
+     * @param recursiveSearch
+     */
     @DataBoundConstructor
-	public HarvestSCM(String broker, String passwordFile, String userId, String password, String projectName,
-			String state, String viewPath, String clientPath, String processName,
-			String recursiveSearch, Boolean useSynchronize, String extraOptions){
-		this.broker=broker;
-		this.passwordFile=passwordFile;
-		this.userId=userId;
-		this.password=password;
-		this.projectName=projectName;
-		this.state=state;
-		this.viewPath=viewPath;
-		this.clientPath=clientPath;
-		this.processName=processName;
-		this.recursiveSearch=recursiveSearch;
-		this.useSynchronize=useSynchronize;
-		this.extraOptions=extraOptions;
-	}
+    public HarvestSCM(String broker, String passwordFile, String userId, String password, String projectName,
+                      String state, String viewPath, String clientPath, String processName,
+                      String recursiveSearch, Boolean useSynchronize, String extraOptions) {
+        this.broker = broker;
+        this.passwordFile = passwordFile;
+        this.userId = userId;
+        this.password = password;
+        this.projectName = projectName;
+        this.state = state;
+        this.viewPath = viewPath;
+        this.clientPath = clientPath;
+        this.processName = processName;
+        this.recursiveSearch = recursiveSearch;
+        this.useSynchronize = useSynchronize;
+        this.extraOptions = extraOptions;
+    }
 
     @Override
-	public boolean supportsPolling() {
-		return isUseSynchronize();
-	}
-
-	private final Log logger = LogFactory.getLog(getClass());
+    public boolean supportsPolling() {
+        return isUseSynchronize();
+    }
 
     /* (non-Javadoc)
-	 * @see hudson.scm.SCM#checkout(hudson.model.AbstractBuild, hudson.Launcher, hudson.FilePath, hudson.model.BuildListener, java.io.File)
+     * @see hudson.scm.SCM#checkout(hudson.model.AbstractBuild, hudson.Launcher, hudson.FilePath, hudson.model.BuildListener, java.io.File)
 	 */
-	@Override
-	public boolean checkout(AbstractBuild<?,?> build, Launcher launcher, FilePath workspace,
-			BuildListener listener, File changeLogFile) throws IOException,
-			InterruptedException {
+    @Override
+    public boolean checkout(AbstractBuild<?, ?> build, Launcher launcher, FilePath workspace,
+                            BuildListener listener, File changeLogFile) throws IOException,
+            InterruptedException {
 
-		if (!useSynchronize){
-	        logger.debug("deleting contents of workspace " + workspace);
-	        workspace.deleteContents();
-		}
+        if (!useSynchronize) {
+            logger.debug("deleting contents of workspace " + workspace);
+            workspace.deleteContents();
+        }
 
-		logger.debug("starting checkout");
+        logger.debug("starting checkout");
 
-		List<HarvestChangeLogEntry> listOfChanges=checkoutInternal(launcher, workspace, listener);
+        List<HarvestChangeLogEntry> listOfChanges = checkoutInternal(launcher, workspace, listener);
 
-        if (!useSynchronize){
+        if (!useSynchronize) {
             createEmptyChangeLog(changeLogFile, listener, "changelog");
         } else {
-        	ChangeLogSet<HarvestChangeLogEntry> history=new HarvestChangeLogSet(build, listOfChanges);
+            ChangeLogSet<HarvestChangeLogEntry> history = new HarvestChangeLogSet(build, listOfChanges);
             FileOutputStream fileOutputStream = new FileOutputStream(changeLogFile);
             HarvestChangeLogSet.saveToChangeLog(fileOutputStream, history);
             fileOutputStream.close();
         }
 
-		String hcoLogFile = workspace.getRemote() + File.separator + "hco.log";
-		try {
-			BufferedReader r = new BufferedReader(new FileReader(hcoLogFile));
-			try {
-				String line = null;
-				while ((line = r.readLine()) != null) {
-					listener.getLogger().println(line);
-				}
-			} finally {
-				if (r != null) {
-					r.close();
-				}
-			}
-		} catch (FileNotFoundException e) {
-			listener.getLogger().println("File " + hcoLogFile + " does not exist, this most likely means there was a failure to call the hco command");
-			throw e;
-		}
+        String hcoLogFile = workspace.getRemote() + File.separator + "hco.log";
+        try {
+            BufferedReader r = new BufferedReader(new FileReader(hcoLogFile));
+            try {
+                String line = null;
+                while ((line = r.readLine()) != null) {
+                    listener.getLogger().println(line);
+                }
+            } finally {
+                if (r != null) {
+                    r.close();
+                }
+            }
+        } catch (FileNotFoundException e) {
+            listener.getLogger().println("File " + hcoLogFile + " does not exist, this most likely means there was a failure to call the hco command");
+            throw e;
+        }
 
         logger.debug("completing checkout");
         return true;
-	}
+    }
 
-	protected List<HarvestChangeLogEntry> checkoutInternal(Launcher launcher,
-			FilePath workspace, TaskListener listener)	throws IOException, InterruptedException, FileNotFoundException {
+    protected List<HarvestChangeLogEntry> checkoutInternal(Launcher launcher,
+                                                           FilePath workspace, TaskListener listener) throws IOException, InterruptedException, FileNotFoundException {
 
-		List<HarvestChangeLogEntry> listOfChanges=new ArrayList<HarvestChangeLogEntry>();
+        List<HarvestChangeLogEntry> listOfChanges = new ArrayList<HarvestChangeLogEntry>();
 
-		ArgumentListBuilder cmd = prepareCommand(getDescriptor().getExecutable(), getDescriptor().getDefaultBroker(), getDescriptor().getDefaultPasswordFile()
-				, getDescriptor().getDefaultUsername(), getDescriptor().getDefaultPassword() , workspace.getRemote());
+        ArgumentListBuilder cmd = prepareCommand(getDescriptor().getExecutable(), getDescriptor().getDefaultBroker(), getDescriptor().getDefaultPasswordFile()
+                , getDescriptor().getDefaultUsername(), getDescriptor().getDefaultPassword(), workspace.getRemote());
 
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
         logger.debug("launching command " + cmd.toList());
 
-		// Try to create the workspacePath if it doesn't exist
-		Path path = Paths.get(generateClientPath(workspace.getRemote()));
-		if (!Files.exists(path)) {
-			listener.getLogger().println("Creating client workspace directory: " + generateClientPath(workspace.getRemote()));
-			FileUtils.forceMkdir(new File(generateClientPath(workspace.getRemote())));
-		}
+        // Try to create the workspacePath if it doesn't exist
+        Path path = Paths.get(generateClientPath(workspace.getRemote()));
+        if (!Files.exists(path)) {
+            listener.getLogger().println("Creating client workspace directory: " + generateClientPath(workspace.getRemote()));
+            FileUtils.forceMkdir(new File(generateClientPath(workspace.getRemote())));
+        }
 
         // ignoring rc as sync might return 3 on success ...
         int rc = launcher.launch().cmds(cmd).stdout(baos).pwd(workspace).join();
 
-        if (isUseSynchronize()){
-        	FileInputStream fileInputStream=null;
-        	try {
-            	fileInputStream=new FileInputStream(new File(workspace.getRemote()+File.separator+"hco.log"));
-            	parse(fileInputStream, listOfChanges);
-        	} finally {
-        		if (fileInputStream!=null){
+        if (isUseSynchronize()) {
+            FileInputStream fileInputStream = null;
+            try {
+                fileInputStream = new FileInputStream(new File(workspace.getRemote() + File.separator + "hco.log"));
+                parse(fileInputStream, listOfChanges);
+            } finally {
+                if (fileInputStream != null) {
                     fileInputStream.close();
-        		}
-        	}
+                }
+            }
         }
 
         return listOfChanges;
-	}
+    }
 
-	protected String generateClientPath(String workspacePath) {
-		// TODO: allowing "." is just for compatibility, will be removed in future releases ...
-		if (StringUtils.isNotEmpty(getClientPath()) && !".".equals(getClientPath())){
-			workspacePath=workspacePath+File.separator+getClientPath();
-		}
-		return workspacePath;
-	}
-	protected ArgumentListBuilder prepareCommand(String executable, String defaultBroker, String defaultPasswordFile, String defaultUsername, String defaultPassword, String workspacePath) throws IOException {
+    protected String generateClientPath(String workspacePath) {
+        // TODO: allowing "." is just for compatibility, will be removed in future releases ...
+        if (StringUtils.isNotEmpty(getClientPath()) && !".".equals(getClientPath())) {
+            workspacePath = workspacePath + File.separator + getClientPath();
+        }
+        return workspacePath;
+    }
 
-		workspacePath = generateClientPath(workspacePath);
-		ArgumentListBuilder cmd = new ArgumentListBuilder();
+    protected ArgumentListBuilder prepareCommand(String executable, String defaultBroker, String defaultPasswordFile, String defaultUsername, String defaultPassword, String workspacePath) throws IOException {
+
+        workspacePath = generateClientPath(workspacePath);
+        ArgumentListBuilder cmd = new ArgumentListBuilder();
         cmd.add(executable);
         cmd.add("-b", StringUtils.isEmpty(getBroker()) ? defaultBroker : getBroker());
 
 		/*
-		If the password file option is used, it will override the user/password options
+        If the password file option is used, it will override the user/password options
 		 */
-		if ((StringUtils.isNotEmpty(defaultPasswordFile) && StringUtils.isEmpty(getUserId()))
-						|| StringUtils.isNotEmpty(getPasswordFile()))
-		{
-			cmd.add("-eh", StringUtils.isNotEmpty(getPasswordFile()) ? getPasswordFile() : defaultPasswordFile );
-		} else {
-			cmd.add("-usr", StringUtils.isEmpty(getUserId()) ? defaultUsername : getUserId());
-			cmd.add("-pw");
-			cmd.add(StringUtils.isEmpty(getPassword()) ? defaultPassword : getPassword(), true);
-		}
+        if ((StringUtils.isNotEmpty(defaultPasswordFile) && StringUtils.isEmpty(getUserId()))
+                || StringUtils.isNotEmpty(getPasswordFile())) {
+            cmd.add("-eh", StringUtils.isNotEmpty(getPasswordFile()) ? getPasswordFile() : defaultPasswordFile);
+        } else {
+            cmd.add("-usr", StringUtils.isEmpty(getUserId()) ? defaultUsername : getUserId());
+            cmd.add("-pw");
+            cmd.add(StringUtils.isEmpty(getPassword()) ? defaultPassword : getPassword(), true);
+        }
 
         cmd.add("-en", getProjectName());
         cmd.add("-st", getState());
@@ -226,311 +207,318 @@ public class HarvestSCM extends SCM {
         cmd.add("-cp");
 
 
-		// On Linux we were ending up with double quotation and the hco command was failing, whereas it works fine on
-		//  Windows
-		if (SystemUtils.IS_OS_LINUX) { cmd.add(workspacePath); } else { cmd.addQuoted(workspacePath); }
+        // On Linux we were ending up with double quotation and the hco command was failing, whereas it works fine on
+        //  Windows
+        if (SystemUtils.IS_OS_LINUX) {
+            cmd.add(workspacePath);
+        } else {
+            cmd.addQuoted(workspacePath);
+        }
         cmd.add("-pn", getProcessName());
         cmd.add("-s");
-		if (SystemUtils.IS_OS_LINUX) { cmd.add(getRecursiveSearch()); } else { cmd.addQuoted(getRecursiveSearch()); }
-		if (isUseSynchronize()){
-			cmd.add("-sy");
-			cmd.add("-nt");
-		} else {
-			cmd.add("-br");
-		}
+        if (SystemUtils.IS_OS_LINUX) {
+            cmd.add(getRecursiveSearch());
+        } else {
+            cmd.addQuoted(getRecursiveSearch());
+        }
+        if (isUseSynchronize()) {
+            cmd.add("-sy");
+            cmd.add("-nt");
+        } else {
+            cmd.add("-br");
+        }
         cmd.add("-r");
 
-		// Add extra options to the end of the command line.   If we add
-		// as a large string, downstream implementation will quote as one arguement
-		if (StringUtils.isNotEmpty(getExtraOptions())) {
-			String[] aList = getExtraOptions().split(",");
-			for (String a : aList) {
-				cmd.add(a);
-			}
-		};
-		return cmd;
-	}
-
-	protected void parse(InputStream inputStream, List<HarvestChangeLogEntry> listOfChanges) throws IOException {
-		BufferedReader br=new BufferedReader(new InputStreamReader(inputStream));
-		Pattern pCheckout = Pattern.compile("I00020110: File (.*);([.\\d]+)  checked out to .*");
-        Pattern pSummary = Pattern.compile("I00060080: Check out summary: Total: (\\d+) ; Success: (\\d+) ; Failed: (\\d+) ; Not Processed: (\\d+) \\.");
-        String line="";
-        while ((line=br.readLine())!=null){
-        	if (StringUtils.indexOf(line, "E")==0){
-        		throw new IllegalArgumentException("error on line "+line);
-        	} else
-        	// I00060040: New connection with Broker broker  established.
-        	if (StringUtils.indexOf(line, "I00060040:")==0){
-        		continue;
-        	} else
-        		// I00020052:  No need to update file c:\dir1\file1  from repository version \repository\dir1\file1;0 .
-        		if (StringUtils.indexOf(line, "I00020052:")==0){
-            		continue;
-        	} else
-        		// I00020110: File \repository\project\dir3\file5;1  checked out to server\\C:\.hudson\jobs\project\workspace\project\dir3\file5 .
-        		if (StringUtils.indexOf(line, "I00020110:")==0) {
-        			HarvestChangeLogEntry e=new HarvestChangeLogEntry();
-        			Matcher m = pCheckout.matcher(line);
-        			if (!m.matches()){
-                		throw new IllegalArgumentException("could not parse checkout line "+line);
-        			}
-        			e.setFullName(m.group(1));
-        			e.setVersion(m.group(2));
-        			listOfChanges.add(e);
-        	} else
-        		// I00060080: Check out summary: Total: 999 ; Success: 999 ; Failed: 0 ; Not Processed: 0 .
-        		if (StringUtils.indexOf(line, "I00060080:")==0){
-        			Matcher m = pSummary.matcher(line);
-        			if (!m.matches()){
-                		throw new IllegalArgumentException("could not parse checkout line "+line);
-        			}
-        			if (!StringUtils.equals("0", m.group(3))){
-                		throw new IllegalArgumentException("failed files in line "+line);
-        			}
-        			if (!StringUtils.equals("0", m.group(4))){
-                		throw new IllegalArgumentException("not processed files in line "+line);
-        			}
-        	} else if (StringUtils.indexOf(line, "Checkout has been executed successfully.")==0){
-        		// Checkout has been executed successfully.
-    			continue;
-        	} else {
-        		throw new IllegalArgumentException("could not parse line "+line);
-        	}
+        // Add extra options to the end of the command line.   If we add
+        // as a large string, downstream implementation will quote as one arguement
+        if (StringUtils.isNotEmpty(getExtraOptions())) {
+            String[] aList = getExtraOptions().split(",");
+            for (String a : aList) {
+                cmd.add(a);
+            }
         }
-	}
+        ;
+        return cmd;
+    }
 
-	/* (non-Javadoc)
-	 * @see hudson.scm.SCM#createChangeLogParser()
-	 */
-	@Override
-	public ChangeLogParser createChangeLogParser() {
-		return new HarvestChangeLogParser();
-	}
+    protected void parse(InputStream inputStream, List<HarvestChangeLogEntry> listOfChanges) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(inputStream));
+        Pattern pCheckout = Pattern.compile("I00020110: File (.*);([.\\d]+)  checked out to .*");
+        Pattern pSummary = Pattern.compile("I00060080: Check out summary: Total: (\\d+) ; Success: (\\d+) ; Failed: (\\d+) ; Not Processed: (\\d+) \\.");
+        String line = "";
+        while ((line = br.readLine()) != null) {
+            if (StringUtils.indexOf(line, "E") == 0) {
+                throw new IllegalArgumentException("error on line " + line);
+            } else
+                // I00060040: New connection with Broker broker  established.
+                if (StringUtils.indexOf(line, "I00060040:") == 0) {
+                    continue;
+                } else
+                    // I00020052:  No need to update file c:\dir1\file1  from repository version \repository\dir1\file1;0 .
+                    if (StringUtils.indexOf(line, "I00020052:") == 0) {
+                        continue;
+                    } else
+                        // I00020110: File \repository\project\dir3\file5;1  checked out to server\\C:\.hudson\jobs\project\workspace\project\dir3\file5 .
+                        if (StringUtils.indexOf(line, "I00020110:") == 0) {
+                            HarvestChangeLogEntry e = new HarvestChangeLogEntry();
+                            Matcher m = pCheckout.matcher(line);
+                            if (!m.matches()) {
+                                throw new IllegalArgumentException("could not parse checkout line " + line);
+                            }
+                            e.setFullName(m.group(1));
+                            e.setVersion(m.group(2));
+                            listOfChanges.add(e);
+                        } else
+                            // I00060080: Check out summary: Total: 999 ; Success: 999 ; Failed: 0 ; Not Processed: 0 .
+                            if (StringUtils.indexOf(line, "I00060080:") == 0) {
+                                Matcher m = pSummary.matcher(line);
+                                if (!m.matches()) {
+                                    throw new IllegalArgumentException("could not parse checkout line " + line);
+                                }
+                                if (!StringUtils.equals("0", m.group(3))) {
+                                    throw new IllegalArgumentException("failed files in line " + line);
+                                }
+                                if (!StringUtils.equals("0", m.group(4))) {
+                                    throw new IllegalArgumentException("not processed files in line " + line);
+                                }
+                            } else if (StringUtils.indexOf(line, "Checkout has been executed successfully.") == 0) {
+                                // Checkout has been executed successfully.
+                                continue;
+                            } else {
+                                throw new IllegalArgumentException("could not parse line " + line);
+                            }
+        }
+    }
 
-	/* (non-Javadoc)
-	 * @see hudson.scm.SCM#getDescriptor()
-	 */
-	@Override
-	public DescriptorImpl getDescriptor() {
-		return DescriptorImpl.DESCRIPTOR;
-	}
+    /* (non-Javadoc)
+     * @see hudson.scm.SCM#createChangeLogParser()
+     */
+    @Override
+    public ChangeLogParser createChangeLogParser() {
+        return new HarvestChangeLogParser();
+    }
 
-	@Override
-	public SCMRevisionState calcRevisionsFromBuild(AbstractBuild<?, ?> build,
-			Launcher launcher, TaskListener listener) throws IOException,
-			InterruptedException {
-		return SCMRevisionState.NONE;
-	}
+    /* (non-Javadoc)
+     * @see hudson.scm.SCM#getDescriptor()
+     */
+    @Override
+    public DescriptorImpl getDescriptor() {
+        return DescriptorImpl.DESCRIPTOR;
+    }
 
-	@Override
-	protected PollingResult compareRemoteRevisionWith(
-			AbstractProject<?, ?> project, Launcher launcher,
-			FilePath workspace, TaskListener listener, SCMRevisionState baseline)
-			throws IOException, InterruptedException {
-		List<HarvestChangeLogEntry> listOfChanges=checkoutInternal(launcher, workspace, listener);
-		if (listOfChanges.size()>0){
-			return PollingResult.SIGNIFICANT;
-		} else {
-			return PollingResult.NO_CHANGES;			
-		}
-	}
+    @Override
+    public SCMRevisionState calcRevisionsFromBuild(AbstractBuild<?, ?> build,
+                                                   Launcher launcher, TaskListener listener) throws IOException,
+            InterruptedException {
+        return SCMRevisionState.NONE;
+    }
 
-    /**
-	 * @return the broker
-	 */
-	public String getBroker() {
-		return broker;
-	}
-
-	/**
-	 * @param broker the broker to set
-	 */
-	public void setBroker(String broker) {
-		this.broker = broker;
-	}
-
-	/**
-	 * @return the password file
-	 */
-	public String getPasswordFile() {
-		return passwordFile;
-	}
-
-	/**
-	 * @param passwordFile the passwordFile to set
-	 */
-	public void setPasswordFile(String passwordFile) {
-		this.passwordFile = passwordFile;
-	}
-
-	/**
-	 * @return the userId
-	 */
-	public String getUserId() {
-		return userId;
-	}
-
-	/**
-	 * @param userId the userId to set
-	 */
-	public void setUserId(String userId) {
-		this.userId = userId;
-	}
-
-	/**
-	 * @return the password
-	 */
-	public String getPassword() {
-		return password;
-	}
-
-	/**
-	 * @param password the password to set
-	 */
-	public void setPassword(String password) {
-		this.password = password;
-	}
-
-	/**
-	 * @return the projectName
-	 */
-	public String getProjectName() {
-		return projectName;
-	}
-
-	/**
-	 * @param projectName the projectName to set
-	 */
-	public void setProjectName(String projectName) {
-		this.projectName = projectName;
-	}
-
-	/**
-	 * @return the state
-	 */
-	public String getState() {
-		return state;
-	}
-
-	/**
-	 * @param state the state to set
-	 */
-	public void setState(String state) {
-		this.state = state;
-	}
-
-	/**
-	 * @return the viewPath
-	 */
-	public String getViewPath() {
-		return viewPath;
-	}
-
-	/**
-	 * @param viewPath the viewPath to set
-	 */
-	public void setViewPath(String viewPath) {
-		this.viewPath = viewPath;
-	}
-
-	/**
-	 * @return the clientPath
-	 */
-	public String getClientPath() {
-		return clientPath;
-	}
-
-	/**
-	 * @param clientPath the clientPath to set
-	 */
-	public void setClientPath(String clientPath) {
-		this.clientPath = clientPath;
-	}
-
-	/**
-	 * @return the processName
-	 */
-	public String getProcessName() {
-		return processName;
-	}
-
-	/**
-	 * @param processName the processName to set
-	 */
-	public void setProcessName(String processName) {
-		this.processName = processName;
-	}
-
-	/**
-	 * @return the recursiveSearch
-	 */
-	public String getRecursiveSearch() {
-		return recursiveSearch;
-	}
-
-	/**
-	 * @param recursiveSearch the recursiveSearch to set
-	 */
-	public void setRecursiveSearch(String recursiveSearch) {
-		this.recursiveSearch = recursiveSearch;
-	}
+    @Override
+    protected PollingResult compareRemoteRevisionWith(
+            AbstractProject<?, ?> project, Launcher launcher,
+            FilePath workspace, TaskListener listener, SCMRevisionState baseline)
+            throws IOException, InterruptedException {
+        List<HarvestChangeLogEntry> listOfChanges = checkoutInternal(launcher, workspace, listener);
+        if (listOfChanges.size() > 0) {
+            return PollingResult.SIGNIFICANT;
+        } else {
+            return PollingResult.NO_CHANGES;
+        }
+    }
 
     /**
-	 * @return the useSynchronize
-	 */
-	public boolean isUseSynchronize() {
-		return useSynchronize;
-	}
+     * @return the broker
+     */
+    public String getBroker() {
+        return broker;
+    }
 
-	/**
-	 * @param useSynchronize the useSynchronize to set
-	 */
-	public void setUseSynchronize(boolean useSynchronize) {
-		this.useSynchronize = useSynchronize;
-	}
+    /**
+     * @param broker the broker to set
+     */
+    public void setBroker(String broker) {
+        this.broker = broker;
+    }
 
-	public String getExtraOptions() {
-		return extraOptions;
-	}
+    /**
+     * @return the password file
+     */
+    public String getPasswordFile() {
+        return passwordFile;
+    }
 
-	public void setExtraOptions(String extraOptions) {
-		this.extraOptions = extraOptions;
-	}
+    /**
+     * @param passwordFile the passwordFile to set
+     */
+    public void setPasswordFile(String passwordFile) {
+        this.passwordFile = passwordFile;
+    }
 
-	public static final class DescriptorImpl extends SCMDescriptor<HarvestSCM> {
+    /**
+     * @return the userId
+     */
+    public String getUserId() {
+        return userId;
+    }
 
-    	private String executable="hco";
-		private String defaultUsername;
-		private String defaultPassword;
-		private String defaultBroker;
-		private String defaultPasswordFile;
+    /**
+     * @param userId the userId to set
+     */
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
 
-		private static final Log LOGGER = LogFactory.getLog(DescriptorImpl.class);
+    /**
+     * @return the password
+     */
+    public String getPassword() {
+        return password;
+    }
 
-		@Extension
-		public static final DescriptorImpl DESCRIPTOR = new DescriptorImpl();
+    /**
+     * @param password the password to set
+     */
+    public void setPassword(String password) {
+        this.password = password;
+    }
 
-		private DescriptorImpl() {
+    /**
+     * @return the projectName
+     */
+    public String getProjectName() {
+        return projectName;
+    }
+
+    /**
+     * @param projectName the projectName to set
+     */
+    public void setProjectName(String projectName) {
+        this.projectName = projectName;
+    }
+
+    /**
+     * @return the state
+     */
+    public String getState() {
+        return state;
+    }
+
+    /**
+     * @param state the state to set
+     */
+    public void setState(String state) {
+        this.state = state;
+    }
+
+    /**
+     * @return the viewPath
+     */
+    public String getViewPath() {
+        return viewPath;
+    }
+
+    /**
+     * @param viewPath the viewPath to set
+     */
+    public void setViewPath(String viewPath) {
+        this.viewPath = viewPath;
+    }
+
+    /**
+     * @return the clientPath
+     */
+    public String getClientPath() {
+        return clientPath;
+    }
+
+    /**
+     * @param clientPath the clientPath to set
+     */
+    public void setClientPath(String clientPath) {
+        this.clientPath = clientPath;
+    }
+
+    /**
+     * @return the processName
+     */
+    public String getProcessName() {
+        return processName;
+    }
+
+    /**
+     * @param processName the processName to set
+     */
+    public void setProcessName(String processName) {
+        this.processName = processName;
+    }
+
+    /**
+     * @return the recursiveSearch
+     */
+    public String getRecursiveSearch() {
+        return recursiveSearch;
+    }
+
+    /**
+     * @param recursiveSearch the recursiveSearch to set
+     */
+    public void setRecursiveSearch(String recursiveSearch) {
+        this.recursiveSearch = recursiveSearch;
+    }
+
+    /**
+     * @return the useSynchronize
+     */
+    public boolean isUseSynchronize() {
+        return useSynchronize;
+    }
+
+    /**
+     * @param useSynchronize the useSynchronize to set
+     */
+    public void setUseSynchronize(boolean useSynchronize) {
+        this.useSynchronize = useSynchronize;
+    }
+
+    public String getExtraOptions() {
+        return extraOptions;
+    }
+
+    public void setExtraOptions(String extraOptions) {
+        this.extraOptions = extraOptions;
+    }
+
+    public static final class DescriptorImpl extends SCMDescriptor<HarvestSCM> {
+
+        @Extension
+        public static final DescriptorImpl DESCRIPTOR = new DescriptorImpl();
+        private static final Log LOGGER = LogFactory.getLog(DescriptorImpl.class);
+        private String executable = "hco";
+        private String defaultUsername;
+        private String defaultPassword;
+        private String defaultBroker;
+        private String defaultPasswordFile;
+
+        private DescriptorImpl() {
             super(HarvestSCM.class, null);
             load();
         }
 
-		/* (non-Javadoc)
-		 * @see hudson.model.Descriptor#configure(org.kohsuke.stapler.StaplerRequest)
-		 */
-		@Override
-		public boolean configure(StaplerRequest req, JSONObject formData) throws FormException {
+        /* (non-Javadoc)
+         * @see hudson.model.Descriptor#configure(org.kohsuke.stapler.StaplerRequest)
+         */
+        @Override
+        public boolean configure(StaplerRequest req, JSONObject formData) throws FormException {
             LOGGER.debug("configuring from " + req);
 
             executable = Util.fixEmpty(req.getParameter("harvest.executable").trim());
-			defaultUsername = Util.fixEmpty(req.getParameter("harvest.defaultUsername"));
-			defaultPassword = Util.fixEmpty(req.getParameter("harvest.defaultPassword"));
-			defaultBroker = Util.fixEmpty(req.getParameter("harvest.defaultBroker"));
-			defaultPasswordFile = Util.fixEmpty(req.getParameter("harvest.defaultPasswordFile"));
-			save();
-			return true;
-		}
+            defaultUsername = Util.fixEmpty(req.getParameter("harvest.defaultUsername"));
+            defaultPassword = Util.fixEmpty(req.getParameter("harvest.defaultPassword"));
+            defaultBroker = Util.fixEmpty(req.getParameter("harvest.defaultBroker"));
+            defaultPasswordFile = Util.fixEmpty(req.getParameter("harvest.defaultPasswordFile"));
+            save();
+            return true;
+        }
 
         /**
          *
@@ -540,27 +528,37 @@ public class HarvestSCM extends SCM {
             return FormValidation.validateExecutable(value);
         }
 
-		@Override
-		public String getDisplayName() {
-			return "CA Harvest";
-		}
+        @Override
+        public String getDisplayName() {
+            return "CA Harvest";
+        }
 
         public String getExecutable() {
             return executable;
         }
-		public void setExecutable(String executable) { this.executable = executable; }
-		public String getDefaultPasswordFile() {
-			return defaultPasswordFile;
-		}
-		public String getDefaultUsername() {
-			return defaultUsername;
-		}
-		public String getDefaultPassword() {
-			return defaultPassword;
-		}
-		public String getDefaultBroker() {
-			return defaultBroker;
-		}
-		public boolean hasDefaultUsername() { return !StringUtils.isEmpty(getDefaultUsername()); }
+
+        public void setExecutable(String executable) {
+            this.executable = executable;
+        }
+
+        public String getDefaultPasswordFile() {
+            return defaultPasswordFile;
+        }
+
+        public String getDefaultUsername() {
+            return defaultUsername;
+        }
+
+        public String getDefaultPassword() {
+            return defaultPassword;
+        }
+
+        public String getDefaultBroker() {
+            return defaultBroker;
+        }
+
+        public boolean hasDefaultUsername() {
+            return !StringUtils.isEmpty(getDefaultUsername());
+        }
     }
 }

--- a/src/main/java/hudson/plugins/harvest/HarvestSCM.java
+++ b/src/main/java/hudson/plugins/harvest/HarvestSCM.java
@@ -18,6 +18,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -68,6 +69,7 @@ public class HarvestSCM extends SCM {
     private String processName = null;
     private String recursiveSearch = null;
 	private boolean useSynchronize=true;
+	private String extraOptions=null;
 
 	/**
 	 * Constructor
@@ -84,7 +86,7 @@ public class HarvestSCM extends SCM {
     @DataBoundConstructor
 	public HarvestSCM(String broker, String passwordFile, String userId, String password, String projectName,
 			String state, String viewPath, String clientPath, String processName,
-			String recursiveSearch, Boolean useSynchronize){
+			String recursiveSearch, Boolean useSynchronize, String extraOptions){
 		this.broker=broker;
 		this.passwordFile=passwordFile;
 		this.userId=userId;
@@ -96,6 +98,7 @@ public class HarvestSCM extends SCM {
 		this.processName=processName;
 		this.recursiveSearch=recursiveSearch;
 		this.useSynchronize=useSynchronize;
+		this.extraOptions=extraOptions;
 	}
 
     @Override
@@ -236,6 +239,15 @@ public class HarvestSCM extends SCM {
 			cmd.add("-br");
 		}
         cmd.add("-r");
+
+		// Add extra options to the end of the command line.   If we add
+		// as a large string, downstream implementation will quote as one arguement
+		if (StringUtils.isNotEmpty(getExtraOptions())) {
+			String[] aList = getExtraOptions().split(",");
+			for (String a : aList) {
+				cmd.add(a);
+			}
+		};
 		return cmd;
 	}
 
@@ -478,6 +490,13 @@ public class HarvestSCM extends SCM {
 		this.useSynchronize = useSynchronize;
 	}
 
+	public String getExtraOptions() {
+		return extraOptions;
+	}
+
+	public void setExtraOptions(String extraOptions) {
+		this.extraOptions = extraOptions;
+	}
 
 	public static final class DescriptorImpl extends SCMDescriptor<HarvestSCM> {
 

--- a/src/main/resources/hudson/plugins/harvest/HarvestSCM/config.jelly
+++ b/src/main/resources/hudson/plugins/harvest/HarvestSCM/config.jelly
@@ -4,91 +4,51 @@
 
     See global.jelly for a general discussion about jelly script.
   -->
-  <f:entry title="Broker" help="${rootURL}/plugin/harvest/broker.html">
-    <!--
-      Creates an text field that shows the value of the "name" property.
-      When submitted, it will be passed to the corresponding constructor parameter.
-    -->
+  <f:entry title="Broker" help="/plugin/harvest/broker.html">
     <f:textbox field="harvest.broker" value="${scm.broker}"/>
   </f:entry>
 
-        <f:entry title="Password File"
-                 help="${rootURL}/plugin/harvest/passfile.html">
+  <f:entry title="Password File" help="/plugin/harvest/passfile.html">
+     <f:textbox name="harvest.passwordFile" value="${scm.passwordFile}" />
+  </f:entry>
 
-            <f:textbox name="harvest.passwordFile"
-                       value="${scm.passwordFile}" />
-        </f:entry>
-
-  <f:entry title="Userid" help="${rootURL}/plugin/harvest/userid.html">
-    <!--
-      Creates an text field that shows the value of the "name" property.
-      When submitted, it will be passed to the corresponding constructor parameter.
-    -->
+  <f:entry title="Userid" help="/plugin/harvest/userid.html">
     <f:textbox field="harvest.userId" value="${scm.userId}"/>
   </f:entry>
   
-  <f:entry title="Password" help="${rootURL}/plugin/harvest/password.html">
-    <!--
-      Creates an text field that shows the value of the "name" property.
-      When submitted, it will be passed to the corresponding constructor parameter.
-    -->
+  <f:entry title="Password" help="/plugin/harvest/password.html">
     <f:password field="harvest.password" value="${scm.password}"/>
   </f:entry>
   
-  <f:entry title="Project Name" help="${rootURL}/plugin/harvest/project.html">
-    <!--
-      Creates an text field that shows the value of the "name" property.
-      When submitted, it will be passed to the corresponding constructor parameter.
-    -->
+  <f:entry title="Project Name" help="/plugin/harvest/project.html">
     <f:textbox field="harvest.projectName" value="${scm.projectName}"/>
   </f:entry>
   
-  <f:entry title="State" help="${rootURL}/plugin/harvest/state.html">
-    <!--
-      Creates an text field that shows the value of the "name" property.
-      When submitted, it will be passed to the corresponding constructor parameter.
-    -->
+  <f:entry title="State" help="/plugin/harvest/state.html">
     <f:textbox field="harvest.state" value="${scm.state}"/>
   </f:entry>
   
-  <f:entry title="View Path (remote)" help="${rootURL}/plugin/harvest/viewpath.html">
-    <!--
-      Creates an text field that shows the value of the "name" property.
-      When submitted, it will be passed to the corresponding constructor parameter.
-    -->
+  <f:entry title="View Path (remote)" help="/plugin/harvest/viewpath.html">
     <f:textbox field="harvest.viewPath" value="${scm.viewPath}"/>
   </f:entry>
   	
-  <f:entry title="Client Path" help="${rootURL}/plugin/harvest/clientpath.html">
-    <!--
-      Creates an text field that shows the value of the "name" property.
-      When submitted, it will be passed to the corresponding constructor parameter.
-    -->
+  <f:entry title="Client Path" help="/plugin/harvest/clientpath.html">
     <f:textbox field="harvest.clientPath" value="${scm.clientPath}"/>
   </f:entry>
   
-  <f:entry title="Process Name" help="${rootURL}/plugin/harvest/processname.html">
-    <!--
-      Creates an text field that shows the value of the "name" property.
-      When submitted, it will be passed to the corresponding constructor parameter.
-    -->
+  <f:entry title="Process Name" help="/plugin/harvest/processname.html">
     <f:textbox field="harvest.processName" value="${scm.processName}"/>
   </f:entry>
   
-  <f:entry title="Recursive Search" help="${rootURL}/plugin/harvest/recursivesearch.html">
-    <!--
-      Creates an text field that shows the value of the "name" property.
-      When submitted, it will be passed to the corresponding constructor parameter.
-    -->
+  <f:entry title="Recursive Search" help="/plugin/harvest/recursivesearch.html">
     <f:textbox field="harvest.recursiveSearch" value="${scm.recursiveSearch}"/>
   </f:entry>
 
-  <f:entry title="Use Synchronize" help="${rootURL}/plugin/harvest/usesynchronize.html">
-    <!--
-      Creates an text field that shows the value of the "name" property.
-      When submitted, it will be passed to the corresponding constructor parameter.
-    <f:checkbox name="harvest.useSynchronize" checked="${scm.useSynchronize}" />
-    -->
+  <f:entry title="Extra Options" help="/plugin/harvest/options.html">
+    <f:textbox field="harvest.extraOptions" value="${scm.extraOptions}"/>
+  </f:entry>
+
+  <f:entry title="Use Synchronize" help="/plugin/harvest/usesynchronize.html">
     <f:checkbox name="harvest.useSynchronize" checked="${scm.useSynchronize}" />
   </f:entry>
 

--- a/src/main/resources/hudson/plugins/harvest/HarvestSCM/config.jelly
+++ b/src/main/resources/hudson/plugins/harvest/HarvestSCM/config.jelly
@@ -12,6 +12,13 @@
     <f:textbox field="harvest.broker" value="${scm.broker}"/>
   </f:entry>
 
+        <f:entry title="Password File"
+                 help="${rootURL}/plugin/harvest/passfile.html">
+
+            <f:textbox name="harvest.passwordFile"
+                       value="${scm.passwordFile}" />
+        </f:entry>
+
   <f:entry title="Userid" help="${rootURL}/plugin/harvest/userid.html">
     <!--
       Creates an text field that shows the value of the "name" property.

--- a/src/main/resources/hudson/plugins/harvest/HarvestSCM/global.jelly
+++ b/src/main/resources/hudson/plugins/harvest/HarvestSCM/global.jelly
@@ -24,5 +24,29 @@
 		               value="${descriptor.executable}"
 		               checkUrl="'${rootURL}/scm/HarvestSCM/executableCheck?value='+escape(this.value)" />
 		</f:entry>
+        <f:entry title="Harvest Default Broker"
+                 help="/plugin/harvest/broker.html">
+
+            <f:textbox name="harvest.defaultBroker"
+                       value="${descriptor.defaultBroker}" />
+        </f:entry>
+        <f:entry title="Harvest Default Password File"
+                 help="/plugin/harvest/passfile.html">
+
+            <f:textbox name="harvest.defaultPasswordFile"
+                       value="${descriptor.defaultPasswordFile}" />
+        </f:entry>
+        <f:entry title="Harvest Default userid"
+                 help="/plugin/harvest/userid.html">
+
+            <f:textbox name="harvest.defaultUsername"
+                       value="${descriptor.defaultUsername}" />
+        </f:entry>
+        <f:entry title="Harvest Default Password"
+                 help="/plugin/harvest/password.html">
+
+            <f:password name="harvest.defaultPassword"
+                       value="${descriptor.defaultPassword}" />
+        </f:entry>
   </f:section>
 </j:jelly>

--- a/src/main/webapp/broker.html
+++ b/src/main/webapp/broker.html
@@ -1,5 +1,5 @@
 <div>
-  <p>
-    The name of the Harvest broker.
-  </p>
+    <p>
+        The name of the Harvest broker.
+    </p>
 </div>

--- a/src/main/webapp/clientpath.html
+++ b/src/main/webapp/clientpath.html
@@ -1,6 +1,6 @@
 <div>
-  <p>
-    Client path will be appended to the workspace location to
-    determine where the Harvest checkout happens at. Can be left empty in most cases.
-  </p>
+    <p>
+        Client path will be appended to the workspace location to
+        determine where the Harvest checkout happens at. Can be left empty in most cases.
+    </p>
 </div>

--- a/src/main/webapp/executable.html
+++ b/src/main/webapp/executable.html
@@ -1,7 +1,7 @@
 <div>
-  <p>
-    This is the path to the hco executable,
-    C:\Program Files\CA\AllFusion Harvest Change Manager\hco.exe for "default"
-    install.
-  </p>
+    <p>
+        This is the path to the hco executable,
+        C:\Program Files\CA\AllFusion Harvest Change Manager\hco.exe for "default"
+        install.
+    </p>
 </div>

--- a/src/main/webapp/options.html
+++ b/src/main/webapp/options.html
@@ -1,6 +1,6 @@
 <div>
-  <p>
-    Additional options which will be appended to the hco command.  Useful for things like -op
-     Options must be passed as a comma separated list
-  </p>
+    <p>
+        Additional options which will be appended to the hco command. Useful for things like -op
+        Options must be passed as a comma separated list
+    </p>
 </div>

--- a/src/main/webapp/options.html
+++ b/src/main/webapp/options.html
@@ -1,0 +1,6 @@
+<div>
+  <p>
+    Additional options which will be appended to the hco command.  Useful for things like -op
+     Options must be passed as a comma separated list
+  </p>
+</div>

--- a/src/main/webapp/passfile.html
+++ b/src/main/webapp/passfile.html
@@ -1,0 +1,5 @@
+<div>
+  <p>
+    Harvest password file, generated using command: svrenc -dir filedirectory -f filename.enc -usr userid -pw password
+  </p>
+</div>

--- a/src/main/webapp/passfile.html
+++ b/src/main/webapp/passfile.html
@@ -1,5 +1,6 @@
 <div>
-  <p>
-    Harvest password file, generated using command: svrenc -dir filedirectory -f filename.enc -usr userid -pw password
-  </p>
+    <p>
+        Harvest password file, generated using command: svrenc -dir filedirectory -f filename.enc -usr userid -pw
+        password
+    </p>
 </div>

--- a/src/main/webapp/password.html
+++ b/src/main/webapp/password.html
@@ -1,5 +1,5 @@
 <div>
-  <p>
-    Harvest login password.
-  </p>
+    <p>
+        Harvest login password.
+    </p>
 </div>

--- a/src/main/webapp/processname.html
+++ b/src/main/webapp/processname.html
@@ -1,5 +1,5 @@
 <div>
-  <p>
-    Harvest process name (line "Check Out for Browse" without quotes).
-  </p>
+    <p>
+        Harvest process name (line "Check Out for Browse" without quotes).
+    </p>
 </div>

--- a/src/main/webapp/project.html
+++ b/src/main/webapp/project.html
@@ -1,5 +1,5 @@
 <div>
-  <p>
-    Harvest project name.
-  </p>
+    <p>
+        Harvest project name.
+    </p>
 </div>

--- a/src/main/webapp/recursivesearch.html
+++ b/src/main/webapp/recursivesearch.html
@@ -1,5 +1,5 @@
 <div>
-  <p>
-    Harvest recursive search mask (like "*" without quotes).
-  </p>
+    <p>
+        Harvest recursive search mask (like "*" without quotes).
+    </p>
 </div>

--- a/src/main/webapp/state.html
+++ b/src/main/webapp/state.html
@@ -1,5 +1,5 @@
 <div>
-  <p>
-    Harvest state.
-  </p>
+    <p>
+        Harvest state.
+    </p>
 </div>

--- a/src/main/webapp/userid.html
+++ b/src/main/webapp/userid.html
@@ -1,5 +1,5 @@
 <div>
-  <p>
-    Harvest login userid.
-  </p>
+    <p>
+        Harvest login userid.
+    </p>
 </div>

--- a/src/main/webapp/usesynchronize.html
+++ b/src/main/webapp/usesynchronize.html
@@ -1,6 +1,6 @@
 <div>
-  <p>
-    If checked, use "synchronize", when updating these files, which makes the checkout much quicker.
-    The drawback is that files modified by the build will not synchronize. 
-  </p>
+    <p>
+        If checked, use "synchronize", when updating these files, which makes the checkout much quicker.
+        The drawback is that files modified by the build will not synchronize.
+    </p>
 </div>

--- a/src/main/webapp/viewpath.html
+++ b/src/main/webapp/viewpath.html
@@ -1,5 +1,5 @@
 <div>
-  <p>
-    Harvest view path (use single \ to separate components).
-  </p>
+    <p>
+        Harvest view path (use single \ to separate components).
+    </p>
 </div>

--- a/src/test/java/hudson/plugins/harvest/HarvestChangeLogSetTest.java
+++ b/src/test/java/hudson/plugins/harvest/HarvestChangeLogSetTest.java
@@ -40,7 +40,7 @@ public class HarvestChangeLogSetTest {
 	@Test
 	public void testParseCheckout() throws IOException, SAXException {		
 		InputStream syncIs=getClass().getResourceAsStream("/hco.sync.txt");
-		HarvestSCM scm=new HarvestSCM("", "", "", "", "", "", "", "", "", false);
+		HarvestSCM scm=new HarvestSCM("", "", "", "", "", "", "", "", "", "", false);
 		List<HarvestChangeLogEntry> listOfChanges=new ArrayList<HarvestChangeLogEntry>();
 		scm.parse(syncIs, listOfChanges);
 		InputStream xmlIs=getClass().getResourceAsStream("/changelog.xml");
@@ -51,7 +51,7 @@ public class HarvestChangeLogSetTest {
 	@Test
 	public void testParseSync() throws IOException, SAXException {		
 		InputStream syncIs=getClass().getResourceAsStream("/hco.sync.txt");
-		HarvestSCM scm=new HarvestSCM("", "", "", "", "", "", "", "", "", true);
+		HarvestSCM scm=new HarvestSCM("", "", "", "", "", "", "", "", "", "", true);
 		List<HarvestChangeLogEntry> listOfChanges=new ArrayList<HarvestChangeLogEntry>();
 		scm.parse(syncIs, listOfChanges);
 		InputStream xmlIs=getClass().getResourceAsStream("/changelog.xml");

--- a/src/test/java/hudson/plugins/harvest/HarvestChangeLogSetTest.java
+++ b/src/test/java/hudson/plugins/harvest/HarvestChangeLogSetTest.java
@@ -40,7 +40,7 @@ public class HarvestChangeLogSetTest {
 	@Test
 	public void testParseCheckout() throws IOException, SAXException {		
 		InputStream syncIs=getClass().getResourceAsStream("/hco.sync.txt");
-		HarvestSCM scm=new HarvestSCM("", "", "", "", "", "", "", "", "", "", false);
+		HarvestSCM scm=new HarvestSCM("", "", "", "", "", "", "", "", "", "", false, "");
 		List<HarvestChangeLogEntry> listOfChanges=new ArrayList<HarvestChangeLogEntry>();
 		scm.parse(syncIs, listOfChanges);
 		InputStream xmlIs=getClass().getResourceAsStream("/changelog.xml");
@@ -51,7 +51,7 @@ public class HarvestChangeLogSetTest {
 	@Test
 	public void testParseSync() throws IOException, SAXException {		
 		InputStream syncIs=getClass().getResourceAsStream("/hco.sync.txt");
-		HarvestSCM scm=new HarvestSCM("", "", "", "", "", "", "", "", "", "", true);
+		HarvestSCM scm=new HarvestSCM("", "", "", "", "", "", "", "", "", "", true, "");
 		List<HarvestChangeLogEntry> listOfChanges=new ArrayList<HarvestChangeLogEntry>();
 		scm.parse(syncIs, listOfChanges);
 		InputStream xmlIs=getClass().getResourceAsStream("/changelog.xml");

--- a/src/test/java/hudson/plugins/harvest/HarvestChangeLogSetTest.java
+++ b/src/test/java/hudson/plugins/harvest/HarvestChangeLogSetTest.java
@@ -1,61 +1,57 @@
 package hudson.plugins.harvest;
 
-import static org.junit.Assert.assertEquals;
 import hudson.scm.ChangeLogSet;
+import org.junit.*;
+import org.xml.sax.SAXException;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.xml.sax.SAXException;
+import static org.junit.Assert.assertEquals;
 
 public class HarvestChangeLogSetTest {
 
-	@BeforeClass
-	public static void setUpBeforeClass() throws Exception {
-	}
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+    }
 
-	@AfterClass
-	public static void tearDownAfterClass() throws Exception {
-	}
+    @AfterClass
+    public static void tearDownAfterClass() throws Exception {
+    }
 
-	@Before
-	public void setUp() throws Exception {
-	}
+    @Before
+    public void setUp() throws Exception {
+    }
 
-	@After
-	public void tearDown() throws Exception {
-	}
-	
-	@Test
-	public void testSaveToChangeLog() {		
-	}
+    @After
+    public void tearDown() throws Exception {
+    }
 
-	@Test
-	public void testParseCheckout() throws IOException, SAXException {		
-		InputStream syncIs=getClass().getResourceAsStream("/hco.sync.txt");
-		HarvestSCM scm=new HarvestSCM("", "", "", "", "", "", "", "", "", "", false, "");
-		List<HarvestChangeLogEntry> listOfChanges=new ArrayList<HarvestChangeLogEntry>();
-		scm.parse(syncIs, listOfChanges);
-		InputStream xmlIs=getClass().getResourceAsStream("/changelog.xml");
-		ChangeLogSet<HarvestChangeLogEntry> xmlChanges=HarvestChangeLogSet.parse(null, xmlIs);
-		assertEquals(listOfChanges.size(), xmlChanges.getItems().length);
-	}
+    @Test
+    public void testSaveToChangeLog() {
+    }
 
-	@Test
-	public void testParseSync() throws IOException, SAXException {		
-		InputStream syncIs=getClass().getResourceAsStream("/hco.sync.txt");
-		HarvestSCM scm=new HarvestSCM("", "", "", "", "", "", "", "", "", "", true, "");
-		List<HarvestChangeLogEntry> listOfChanges=new ArrayList<HarvestChangeLogEntry>();
-		scm.parse(syncIs, listOfChanges);
-		InputStream xmlIs=getClass().getResourceAsStream("/changelog.xml");
-		ChangeLogSet<HarvestChangeLogEntry> xmlChanges=HarvestChangeLogSet.parse(null, xmlIs);
-		assertEquals(listOfChanges.size(), xmlChanges.getItems().length);
-	}
+    @Test
+    public void testParseCheckout() throws IOException, SAXException {
+        InputStream syncIs = getClass().getResourceAsStream("/hco.sync.txt");
+        HarvestSCM scm = new HarvestSCM("", "", "", "", "", "", "", "", "", "", false, "");
+        List<HarvestChangeLogEntry> listOfChanges = new ArrayList<HarvestChangeLogEntry>();
+        scm.parse(syncIs, listOfChanges);
+        InputStream xmlIs = getClass().getResourceAsStream("/changelog.xml");
+        ChangeLogSet<HarvestChangeLogEntry> xmlChanges = HarvestChangeLogSet.parse(null, xmlIs);
+        assertEquals(listOfChanges.size(), xmlChanges.getItems().length);
+    }
+
+    @Test
+    public void testParseSync() throws IOException, SAXException {
+        InputStream syncIs = getClass().getResourceAsStream("/hco.sync.txt");
+        HarvestSCM scm = new HarvestSCM("", "", "", "", "", "", "", "", "", "", true, "");
+        List<HarvestChangeLogEntry> listOfChanges = new ArrayList<HarvestChangeLogEntry>();
+        scm.parse(syncIs, listOfChanges);
+        InputStream xmlIs = getClass().getResourceAsStream("/changelog.xml");
+        ChangeLogSet<HarvestChangeLogEntry> xmlChanges = HarvestChangeLogSet.parse(null, xmlIs);
+        assertEquals(listOfChanges.size(), xmlChanges.getItems().length);
+    }
 }

--- a/src/test/java/hudson/plugins/harvest/HarvestSCMTest.java
+++ b/src/test/java/hudson/plugins/harvest/HarvestSCMTest.java
@@ -1,13 +1,12 @@
 /**
- * 
+ *
  */
 package hudson.plugins.harvest;
 
-import static org.junit.Assert.*;
-import org.apache.commons.lang.SystemUtils;
-
 import hudson.scm.ChangeLogSet;
 import hudson.util.ArgumentListBuilder;
+import org.apache.commons.lang.SystemUtils;
+import org.junit.*;
 
 import java.io.File;
 import java.io.IOException;
@@ -15,98 +14,93 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 /**
  * @author G&aacute;bor Lipt&aacute;k
- *
  */
 public class HarvestSCMTest {
 
-	@BeforeClass
-	public static void setUpBeforeClass() throws Exception {
-	}
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+    }
 
-	@AfterClass
-	public static void tearDownAfterClass() throws Exception {
-	}
+    @AfterClass
+    public static void tearDownAfterClass() throws Exception {
+    }
 
-	@Before
-	public void setUp() throws Exception {
-	}
+    @Before
+    public void setUp() throws Exception {
+    }
 
-	@After
-	public void tearDown() throws Exception {
-	}
+    @After
+    public void tearDown() throws Exception {
+    }
 
-	@Test
-	public final void testParse() throws IOException {
-		InputStream is=getClass().getResourceAsStream("/hco.sync.txt");
-		HarvestSCM scm=new HarvestSCM("", "", "", "", "", "", "", "", "", "", true, "");
-		List<HarvestChangeLogEntry> listOfChanges=new ArrayList<HarvestChangeLogEntry>();
-		scm.parse(is, listOfChanges);
-    	ChangeLogSet<HarvestChangeLogEntry> history=new HarvestChangeLogSet(null, listOfChanges);
-		assertEquals(2, history.getItems().length);
-	}
+    @Test
+    public final void testParse() throws IOException {
+        InputStream is = getClass().getResourceAsStream("/hco.sync.txt");
+        HarvestSCM scm = new HarvestSCM("", "", "", "", "", "", "", "", "", "", true, "");
+        List<HarvestChangeLogEntry> listOfChanges = new ArrayList<HarvestChangeLogEntry>();
+        scm.parse(is, listOfChanges);
+        ChangeLogSet<HarvestChangeLogEntry> history = new HarvestChangeLogSet(null, listOfChanges);
+        assertEquals(2, history.getItems().length);
+    }
 
-	@Test (expected=IllegalArgumentException.class)
-	public final void testParseError() throws IOException {
-		InputStream is=getClass().getResourceAsStream("/hco.syncerror.txt");
-		HarvestSCM scm=new HarvestSCM("", "", "", "", "", "", "", "", "", "", true, "");
-		List<HarvestChangeLogEntry> listOfChanges=new ArrayList<HarvestChangeLogEntry>();
-		scm.parse(is, listOfChanges);
-	}
-	
-	@Test (expected=IllegalArgumentException.class)
-	public final void testParseFail() throws IOException {
-		InputStream is=getClass().getResourceAsStream("/hco.syncfail.txt");
-		HarvestSCM scm=new HarvestSCM("", "", "", "", "", "", "", "", "", "", true, "");
-		List<HarvestChangeLogEntry> listOfChanges=new ArrayList<HarvestChangeLogEntry>();
-		scm.parse(is, listOfChanges);
-	}
-	
-	@Test
-	public final void testPrepareCommandSynch()throws Exception{
-		HarvestSCM scm=new HarvestSCM("broker", null, "user", "password",
-				"project", "DEV", "/Project", "bar", "Checkout", "*", true, "");
-		ArgumentListBuilder cmd=scm.prepareCommand("hco.exe", null, null, null, null, "c:\\foo");
-		List<String> parts=cmd.toList();
-		StringBuffer sb=new StringBuffer();
-		for (String s: parts){
-			sb.append(s);
-			sb.append(" ");
-		}
-                if (SystemUtils.IS_OS_LINUX) {
-		  assertEquals("hco.exe -b broker -usr user -pw password -en project -st DEV -vp /Project -cp c:\\foo"+File.separator+"bar -pn Checkout -s * -sy -nt -r "
-				, sb.toString());
-                } else {  
-		  assertEquals("hco.exe -b broker -usr user -pw password -en project -st DEV -vp /Project -cp \"c:\\foo"+File.separator+"bar\" -pn Checkout -s \"*\" -sy -nt -r "
-				, sb.toString());
-                }
+    @Test(expected = IllegalArgumentException.class)
+    public final void testParseError() throws IOException {
+        InputStream is = getClass().getResourceAsStream("/hco.syncerror.txt");
+        HarvestSCM scm = new HarvestSCM("", "", "", "", "", "", "", "", "", "", true, "");
+        List<HarvestChangeLogEntry> listOfChanges = new ArrayList<HarvestChangeLogEntry>();
+        scm.parse(is, listOfChanges);
+    }
 
-	}
+    @Test(expected = IllegalArgumentException.class)
+    public final void testParseFail() throws IOException {
+        InputStream is = getClass().getResourceAsStream("/hco.syncfail.txt");
+        HarvestSCM scm = new HarvestSCM("", "", "", "", "", "", "", "", "", "", true, "");
+        List<HarvestChangeLogEntry> listOfChanges = new ArrayList<HarvestChangeLogEntry>();
+        scm.parse(is, listOfChanges);
+    }
 
-	@Test
-	public final void testPrepareCommandNoSynch() throws Exception{
-		HarvestSCM scm=new HarvestSCM("broker", null, "user", "password",
-				"project", "DEV", "/Project", "bar", "Checkout", "*", false, "");
-		ArgumentListBuilder cmd=scm.prepareCommand("hco.exe", null, null, null, null, "c:\\foo");
-		List<String> parts=cmd.toList();
-		StringBuffer sb=new StringBuffer();
-		for (String s: parts){
-			sb.append(s);
-			sb.append(" ");
-		}
-                if (SystemUtils.IS_OS_LINUX) {
-		  assertEquals("hco.exe -b broker -usr user -pw password -en project -st DEV -vp /Project -cp c:\\foo"+File.separator+"bar -pn Checkout -s * -br -r "
-				, sb.toString());
-                } else {
-		  assertEquals("hco.exe -b broker -usr user -pw password -en project -st DEV -vp /Project -cp \"c:\\foo"+File.separator+"bar\" -pn Checkout -s \"*\" -br -r "
-				, sb.toString());
-                }
-	}
+    @Test
+    public final void testPrepareCommandSynch() throws Exception {
+        HarvestSCM scm = new HarvestSCM("broker", null, "user", "password",
+                "project", "DEV", "/Project", "bar", "Checkout", "*", true, "");
+        ArgumentListBuilder cmd = scm.prepareCommand("hco.exe", null, null, null, null, "c:\\foo");
+        List<String> parts = cmd.toList();
+        StringBuffer sb = new StringBuffer();
+        for (String s : parts) {
+            sb.append(s);
+            sb.append(" ");
+        }
+        if (SystemUtils.IS_OS_LINUX) {
+            assertEquals("hco.exe -b broker -usr user -pw password -en project -st DEV -vp /Project -cp c:\\foo" + File.separator + "bar -pn Checkout -s * -sy -nt -r "
+                    , sb.toString());
+        } else {
+            assertEquals("hco.exe -b broker -usr user -pw password -en project -st DEV -vp /Project -cp \"c:\\foo" + File.separator + "bar\" -pn Checkout -s \"*\" -sy -nt -r "
+                    , sb.toString());
+        }
+
+    }
+
+    @Test
+    public final void testPrepareCommandNoSynch() throws Exception {
+        HarvestSCM scm = new HarvestSCM("broker", null, "user", "password",
+                "project", "DEV", "/Project", "bar", "Checkout", "*", false, "");
+        ArgumentListBuilder cmd = scm.prepareCommand("hco.exe", null, null, null, null, "c:\\foo");
+        List<String> parts = cmd.toList();
+        StringBuffer sb = new StringBuffer();
+        for (String s : parts) {
+            sb.append(s);
+            sb.append(" ");
+        }
+        if (SystemUtils.IS_OS_LINUX) {
+            assertEquals("hco.exe -b broker -usr user -pw password -en project -st DEV -vp /Project -cp c:\\foo" + File.separator + "bar -pn Checkout -s * -br -r "
+                    , sb.toString());
+        } else {
+            assertEquals("hco.exe -b broker -usr user -pw password -en project -st DEV -vp /Project -cp \"c:\\foo" + File.separator + "bar\" -pn Checkout -s \"*\" -br -r "
+                    , sb.toString());
+        }
+    }
 }

--- a/src/test/java/hudson/plugins/harvest/HarvestSCMTest.java
+++ b/src/test/java/hudson/plugins/harvest/HarvestSCMTest.java
@@ -46,7 +46,7 @@ public class HarvestSCMTest {
 	@Test
 	public final void testParse() throws IOException {
 		InputStream is=getClass().getResourceAsStream("/hco.sync.txt");
-		HarvestSCM scm=new HarvestSCM("", "", "", "", "", "", "", "", "", "", true);
+		HarvestSCM scm=new HarvestSCM("", "", "", "", "", "", "", "", "", "", true, "");
 		List<HarvestChangeLogEntry> listOfChanges=new ArrayList<HarvestChangeLogEntry>();
 		scm.parse(is, listOfChanges);
     	ChangeLogSet<HarvestChangeLogEntry> history=new HarvestChangeLogSet(null, listOfChanges);
@@ -56,7 +56,7 @@ public class HarvestSCMTest {
 	@Test (expected=IllegalArgumentException.class)
 	public final void testParseError() throws IOException {
 		InputStream is=getClass().getResourceAsStream("/hco.syncerror.txt");
-		HarvestSCM scm=new HarvestSCM("", "", "", "", "", "", "", "", "", "", true);
+		HarvestSCM scm=new HarvestSCM("", "", "", "", "", "", "", "", "", "", true, "");
 		List<HarvestChangeLogEntry> listOfChanges=new ArrayList<HarvestChangeLogEntry>();
 		scm.parse(is, listOfChanges);
 	}
@@ -64,7 +64,7 @@ public class HarvestSCMTest {
 	@Test (expected=IllegalArgumentException.class)
 	public final void testParseFail() throws IOException {
 		InputStream is=getClass().getResourceAsStream("/hco.syncfail.txt");
-		HarvestSCM scm=new HarvestSCM("", "", "", "", "", "", "", "", "", "", true);
+		HarvestSCM scm=new HarvestSCM("", "", "", "", "", "", "", "", "", "", true, "");
 		List<HarvestChangeLogEntry> listOfChanges=new ArrayList<HarvestChangeLogEntry>();
 		scm.parse(is, listOfChanges);
 	}
@@ -72,7 +72,7 @@ public class HarvestSCMTest {
 	@Test
 	public final void testPrepareCommandSynch()throws Exception{
 		HarvestSCM scm=new HarvestSCM("broker", null, "user", "password",
-				"project", "DEV", "/Project", "bar", "Checkout", "*", true);
+				"project", "DEV", "/Project", "bar", "Checkout", "*", true, "");
 		ArgumentListBuilder cmd=scm.prepareCommand("hco.exe", null, null, null, null, "c:\\foo");
 		List<String> parts=cmd.toList();
 		StringBuffer sb=new StringBuffer();
@@ -93,7 +93,7 @@ public class HarvestSCMTest {
 	@Test
 	public final void testPrepareCommandNoSynch() throws Exception{
 		HarvestSCM scm=new HarvestSCM("broker", null, "user", "password",
-				"project", "DEV", "/Project", "bar", "Checkout", "*", false);
+				"project", "DEV", "/Project", "bar", "Checkout", "*", false, "");
 		ArgumentListBuilder cmd=scm.prepareCommand("hco.exe", null, null, null, null, "c:\\foo");
 		List<String> parts=cmd.toList();
 		StringBuffer sb=new StringBuffer();

--- a/src/test/java/hudson/plugins/harvest/HarvestSCMTest.java
+++ b/src/test/java/hudson/plugins/harvest/HarvestSCMTest.java
@@ -45,7 +45,7 @@ public class HarvestSCMTest {
 	@Test
 	public final void testParse() throws IOException {
 		InputStream is=getClass().getResourceAsStream("/hco.sync.txt");
-		HarvestSCM scm=new HarvestSCM("", "", "", "", "", "", "", "", "", true);
+		HarvestSCM scm=new HarvestSCM("", "", "", "", "", "", "", "", "", "", true);
 		List<HarvestChangeLogEntry> listOfChanges=new ArrayList<HarvestChangeLogEntry>();
 		scm.parse(is, listOfChanges);
     	ChangeLogSet<HarvestChangeLogEntry> history=new HarvestChangeLogSet(null, listOfChanges);
@@ -55,7 +55,7 @@ public class HarvestSCMTest {
 	@Test (expected=IllegalArgumentException.class)
 	public final void testParseError() throws IOException {
 		InputStream is=getClass().getResourceAsStream("/hco.syncerror.txt");
-		HarvestSCM scm=new HarvestSCM("", "", "", "", "", "", "", "", "", true);
+		HarvestSCM scm=new HarvestSCM("", "", "", "", "", "", "", "", "", "", true);
 		List<HarvestChangeLogEntry> listOfChanges=new ArrayList<HarvestChangeLogEntry>();
 		scm.parse(is, listOfChanges);
 	}
@@ -63,16 +63,16 @@ public class HarvestSCMTest {
 	@Test (expected=IllegalArgumentException.class)
 	public final void testParseFail() throws IOException {
 		InputStream is=getClass().getResourceAsStream("/hco.syncfail.txt");
-		HarvestSCM scm=new HarvestSCM("", "", "", "", "", "", "", "", "", true);
+		HarvestSCM scm=new HarvestSCM("", "", "", "", "", "", "", "", "", "", true);
 		List<HarvestChangeLogEntry> listOfChanges=new ArrayList<HarvestChangeLogEntry>();
 		scm.parse(is, listOfChanges);
 	}
 	
 	@Test
-	public final void testPrepareCommandSynch(){
-		HarvestSCM scm=new HarvestSCM("broker", "user", "password",
+	public final void testPrepareCommandSynch()throws Exception{
+		HarvestSCM scm=new HarvestSCM("broker", null, "user", "password",
 				"project", "DEV", "/Project", "bar", "Checkout", "", true);
-		ArgumentListBuilder cmd=scm.prepareCommand("hco.exe", "c:\\foo");
+		ArgumentListBuilder cmd=scm.prepareCommand("hco.exe", null, null, null, null, "c:\\foo");
 		List<String> parts=cmd.toList();
 		StringBuffer sb=new StringBuffer();
 		for (String s: parts){
@@ -84,10 +84,10 @@ public class HarvestSCMTest {
 	}
 
 	@Test
-	public final void testPrepareCommandNoSynch(){
-		HarvestSCM scm=new HarvestSCM("broker", "user", "password",
+	public final void testPrepareCommandNoSynch() throws Exception{
+		HarvestSCM scm=new HarvestSCM("broker", null, "user", "password",
 				"project", "DEV", "/Project", "bar", "Checkout", "", false);
-		ArgumentListBuilder cmd=scm.prepareCommand("hco.exe", "c:\\foo");
+		ArgumentListBuilder cmd=scm.prepareCommand("hco.exe", null, null, null, null, "c:\\foo");
 		List<String> parts=cmd.toList();
 		StringBuffer sb=new StringBuffer();
 		for (String s: parts){

--- a/src/test/java/hudson/plugins/harvest/HarvestSCMTest.java
+++ b/src/test/java/hudson/plugins/harvest/HarvestSCMTest.java
@@ -4,6 +4,7 @@
 package hudson.plugins.harvest;
 
 import static org.junit.Assert.*;
+import org.apache.commons.lang.SystemUtils;
 
 import hudson.scm.ChangeLogSet;
 import hudson.util.ArgumentListBuilder;
@@ -71,7 +72,7 @@ public class HarvestSCMTest {
 	@Test
 	public final void testPrepareCommandSynch()throws Exception{
 		HarvestSCM scm=new HarvestSCM("broker", null, "user", "password",
-				"project", "DEV", "/Project", "bar", "Checkout", "", true);
+				"project", "DEV", "/Project", "bar", "Checkout", "*", true);
 		ArgumentListBuilder cmd=scm.prepareCommand("hco.exe", null, null, null, null, "c:\\foo");
 		List<String> parts=cmd.toList();
 		StringBuffer sb=new StringBuffer();
@@ -79,14 +80,20 @@ public class HarvestSCMTest {
 			sb.append(s);
 			sb.append(" ");
 		}
-		assertEquals("hco.exe -b broker -usr user -pw password -en project -st DEV -vp /Project -cp \"c:\\foo"+File.separator+"bar\" -pn Checkout -s \"\" -sy -nt -r "
+                if (SystemUtils.IS_OS_LINUX) {
+		  assertEquals("hco.exe -b broker -usr user -pw password -en project -st DEV -vp /Project -cp c:\\foo"+File.separator+"bar -pn Checkout -s * -sy -nt -r "
 				, sb.toString());
+                } else {  
+		  assertEquals("hco.exe -b broker -usr user -pw password -en project -st DEV -vp /Project -cp \"c:\\foo"+File.separator+"bar\" -pn Checkout -s \"*\" -sy -nt -r "
+				, sb.toString());
+                }
+
 	}
 
 	@Test
 	public final void testPrepareCommandNoSynch() throws Exception{
 		HarvestSCM scm=new HarvestSCM("broker", null, "user", "password",
-				"project", "DEV", "/Project", "bar", "Checkout", "", false);
+				"project", "DEV", "/Project", "bar", "Checkout", "*", false);
 		ArgumentListBuilder cmd=scm.prepareCommand("hco.exe", null, null, null, null, "c:\\foo");
 		List<String> parts=cmd.toList();
 		StringBuffer sb=new StringBuffer();
@@ -94,7 +101,12 @@ public class HarvestSCMTest {
 			sb.append(s);
 			sb.append(" ");
 		}
-		assertEquals("hco.exe -b broker -usr user -pw password -en project -st DEV -vp /Project -cp \"c:\\foo"+File.separator+"bar\" -pn Checkout -s \"\" -br -r "
+                if (SystemUtils.IS_OS_LINUX) {
+		  assertEquals("hco.exe -b broker -usr user -pw password -en project -st DEV -vp /Project -cp c:\\foo"+File.separator+"bar -pn Checkout -s * -br -r "
 				, sb.toString());
+                } else {
+		  assertEquals("hco.exe -b broker -usr user -pw password -en project -st DEV -vp /Project -cp \"c:\\foo"+File.separator+"bar\" -pn Checkout -s \"*\" -br -r "
+				, sb.toString());
+                }
 	}
 }

--- a/src/test/resources/changelog.xml
+++ b/src/test/resources/changelog.xml
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <history>
-<entry>
-<user>unknown</user>
-<msg></msg>
-<fullName>\repository\project\dir3\file5</fullName>
-</entry>
-<entry>
-<user>unknown</user>
-<msg></msg>
-<fullName>\repository\project\dir3\file6</fullName>
-</entry>
+    <entry>
+        <user>unknown</user>
+        <msg></msg>
+        <fullName>\repository\project\dir3\file5</fullName>
+    </entry>
+    <entry>
+        <user>unknown</user>
+        <msg></msg>
+        <fullName>\repository\project\dir3\file6</fullName>
+    </entry>
 </history>


### PR DESCRIPTION
- parent plugin v1.620 from v1.400
- Resolve double quoting issue executing hco command execution on Linux
- Do not display the user password in logfiles
- Create "Client Path" directory if it doesn't exist
- Add the ability to use the "Password File" option for hco so we can leverage an externally encrypted password file instead of storing the password in Jenkins
- Add the ability to set a global default broker, user, password, pwd file which will take effect if they are not specified at the job level